### PR TITLE
dbt tracking

### DIFF
--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -32,6 +32,8 @@ def import_dbt():
 from .tracking import (
     set_entrypoint_name,
     set_dbt_user_id,
+    set_dbt_version,
+    set_dbt_project_id,
     create_end_event_json,
     create_start_event_json,
     send_event_json,
@@ -88,6 +90,8 @@ def dbt_diff(
     # custom schemas is default dbt behavior, so default to True if the var doesn't exist
     custom_schemas = True if custom_schemas is None else custom_schemas
     set_dbt_user_id(dbt_parser.dbt_user_id)
+    set_dbt_version(dbt_parser.dbt_version)
+    set_dbt_project_id(dbt_parser.dbt_project_id)
 
     if is_cloud:
         if datasource_id is None:
@@ -403,6 +407,8 @@ class DbtParser:
         self.project_dict = self.get_project_dict()
         self.manifest_obj = self.get_manifest_obj()
         self.dbt_user_id = self.manifest_obj.metadata.user_id
+        self.dbt_version = self.manifest_obj.metadata.dbt_version
+        self.dbt_project_id = self.manifest_obj.metadata.project_id
         self.requires_upper = False
         self.threads = None
         self.unique_columns = self.get_unique_columns()

--- a/data_diff/tracking.py
+++ b/data_diff/tracking.py
@@ -64,6 +64,13 @@ def set_dbt_user_id(s):
     global dbt_user_id
     dbt_user_id = s
 
+def set_dbt_version(s):
+    global dbt_version
+    dbt_version = s
+
+def set_dbt_project_id(s):
+    global dbt_project_id
+    dbt_project_id = s
 
 def get_anonymous_id():
     global g_anonymous_id
@@ -87,6 +94,8 @@ def create_start_event_json(diff_options: Dict[str, Any]):
             "data_diff_version:": __version__,
             "entrypoint_name": entrypoint_name,
             "dbt_user_id": dbt_user_id,
+            "dbt_version": dbt_version,
+            "dbt_project_id": dbt_project_id,
         },
     }
 
@@ -122,6 +131,8 @@ def create_end_event_json(
             "is_cloud": is_cloud,
             "diff_id": diff_id,
             "dbt_user_id": dbt_user_id,
+            "dbt_version": dbt_version,
+            "dbt_project_id": dbt_project_id,
         },
     }
 


### PR DESCRIPTION
To help inform product development, adding dbt_version and dbt_project_id to tracking. I followed the same conventions as we did for dbt_user_id.

Test events were successful in the dev Ruddestack space:
<img width="1442" alt="Screen Shot 2023-04-06 at 10 10 18 AM" src="https://user-images.githubusercontent.com/40182913/230449153-5d144e4f-0423-49b3-a81c-7c33ee6c2f13.png">

<img width="1456" alt="Screen Shot 2023-04-06 at 10 10 26 AM" src="https://user-images.githubusercontent.com/40182913/230449143-e6265bd9-9a26-4617-b183-a1c21eca5ae6.png">
