### PR TITLE
Triage label

### DIFF
--- a/.github/workflows/triage_labels.yml
+++ b/.github/workflows/triage_labels.yml
@@ -1,0 +1,21 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["triage"]
+            })


### PR DESCRIPTION
Creating a workflow to add a `triage` label to new and reopened issues

borrowed from here:
https://docs.github.com/en/enterprise-cloud@latest/actions/managing-issues-and-pull-requests/adding-labels-to-issues